### PR TITLE
Fix macOS font handling

### DIFF
--- a/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms.Tests/LibreWinForms.System.Windows.Forms.Tests.csproj
+++ b/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms.Tests/LibreWinForms.System.Windows.Forms.Tests.csproj
@@ -11,5 +11,12 @@
   <ItemGroup>
     <ProjectReference Include="..\LibreWinForms.System.Windows.Forms\LibreWinForms.System.Windows.Forms.csproj"
                       AdditionalProperties="LibreWinFormsReferenceMode=$(LibreWinFormsReferenceMode);LibreWinFormsBridgePackageVersion=$(LibreWinFormsBridgePackageVersion);LibreWinFormsProGpuPackageVersion=$(LibreWinFormsProGpuPackageVersion)" />
+    <PackageReference Include="System.Drawing.Common"
+                      Version="10.0.0"
+                      GeneratePathProperty="true"
+                      ExcludeAssets="all"
+                      PrivateAssets="all" />
+    <AssemblyMetadata Include="MicrosoftSystemDrawingCommonPath"
+                      Value="$(PkgSystem_Drawing_Common)\lib\net10.0\System.Drawing.Common.dll" />
   </ItemGroup>
 </Project>

--- a/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms.Tests/SystemFontCompatibilityBehaviorTests.cs
+++ b/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms.Tests/SystemFontCompatibilityBehaviorTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace LibreWinForms.SystemWindowsForms.Tests;
+
+internal static class SystemFontCompatibilityBehaviorTests
+{
+    public static void Run()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        string microsoftDrawingPath = Assembly.GetExecutingAssembly()
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(static attribute => attribute.Key == "MicrosoftSystemDrawingCommonPath")
+            .Value ?? throw new InvalidOperationException("Microsoft System.Drawing.Common path is missing.");
+        string formsPath = typeof(System.Windows.Forms.Control).Assembly.Location;
+
+        using var context = new MicrosoftDrawingFirstLoadContext(microsoftDrawingPath, formsPath);
+        Assembly drawingAssembly = context.LoadFromAssemblyPath(microsoftDrawingPath);
+        AssertTrue(
+            drawingAssembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company == "Microsoft Corporation",
+            "The compatibility test did not load Microsoft System.Drawing.Common first.");
+
+        Assembly formsAssembly = context.LoadFromAssemblyPath(formsPath);
+        AssertNotNull(Create(formsAssembly, "System.Windows.Forms.Control"), "Control construction failed.");
+        AssertNotNull(Create(formsAssembly, "System.Windows.Forms.Label"), "Label construction failed.");
+        AssertNotNull(GetStaticProperty(formsAssembly, "System.Windows.Forms.Control", "DefaultFont"),
+            "Control.DefaultFont returned null.");
+        AssertNotNull(GetStaticProperty(formsAssembly, "System.Windows.Forms.SystemInformation", "MenuFont"),
+            "SystemInformation.MenuFont returned null.");
+
+        object fontDialog = Create(formsAssembly, "System.Windows.Forms.FontDialog");
+        AssertNotNull(fontDialog.GetType().GetProperty("Font")?.GetValue(fontDialog),
+            "FontDialog.Font returned null.");
+
+        Console.WriteLine("LibreWinForms system-font compatibility tests passed: Microsoft System.Drawing.Common host=1.");
+    }
+
+    private static object Create(Assembly assembly, string typeName) =>
+        Activator.CreateInstance(assembly.GetType(typeName, throwOnError: true)!)
+        ?? throw new InvalidOperationException($"{typeName} construction returned null.");
+
+    private static object? GetStaticProperty(Assembly assembly, string typeName, string propertyName) =>
+        assembly.GetType(typeName, throwOnError: true)!.GetProperty(propertyName)?.GetValue(null);
+
+    private static void AssertNotNull(object? value, string message)
+    {
+        if (value is null)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private static void AssertTrue(bool value, string message)
+    {
+        if (!value)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private sealed class MicrosoftDrawingFirstLoadContext : AssemblyLoadContext, IDisposable
+    {
+        private readonly string _microsoftDrawingPath;
+        private readonly string _microsoftDrawingDirectory;
+        private readonly string _formsDirectory;
+
+        public MicrosoftDrawingFirstLoadContext(string microsoftDrawingPath, string formsPath)
+            : base(nameof(MicrosoftDrawingFirstLoadContext), isCollectible: true)
+        {
+            _microsoftDrawingPath = microsoftDrawingPath;
+            _microsoftDrawingDirectory = Path.GetDirectoryName(microsoftDrawingPath)
+                ?? throw new InvalidOperationException("Microsoft System.Drawing.Common directory is missing.");
+            _formsDirectory = Path.GetDirectoryName(formsPath)
+                ?? throw new InvalidOperationException("LibreWinForms assembly directory is missing.");
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            if (assemblyName.Name == "System.Drawing.Common")
+            {
+                return LoadFromAssemblyPath(_microsoftDrawingPath);
+            }
+
+            string candidate = Path.Combine(_microsoftDrawingDirectory, $"{assemblyName.Name}.dll");
+            if (File.Exists(candidate))
+            {
+                return LoadFromAssemblyPath(candidate);
+            }
+
+            candidate = Path.Combine(_formsDirectory, $"{assemblyName.Name}.dll");
+            return File.Exists(candidate) ? LoadFromAssemblyPath(candidate) : null;
+        }
+
+        public void Dispose() => Unload();
+    }
+}

--- a/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms.Tests/TreeViewBehaviorTests.cs
+++ b/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms.Tests/TreeViewBehaviorTests.cs
@@ -11,6 +11,8 @@ internal static class TreeViewBehaviorTests
     {
         try
         {
+            SystemFontCompatibilityBehaviorTests.Run();
+
             if (args.Length == 1 && string.Equals(args[0], "datagridview-new-row", StringComparison.Ordinal))
             {
                 DataGridViewNewRowBehaviorTests.Run();

--- a/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms/src/WinFormsCompatTypes.cs
+++ b/src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms/src/WinFormsCompatTypes.cs
@@ -12,6 +12,43 @@ using ProGPU.Wpf.Interop;
 
 namespace System.Windows.Forms;
 
+/// <summary>
+/// Wraps <see cref="SystemFonts"/> lookups so this portable compat layer stays usable even when the
+/// process has already loaded the real Microsoft System.Drawing.Common assembly instead of ProGPU's
+/// portable stub (both share the simple name "System.Drawing.Common" and only one wins per process) -
+/// the real assembly throws PlatformNotSupportedException for these members off Windows.
+/// </summary>
+internal static class SafePortableSystemFonts
+{
+    // Built once: when the process-wide System.Drawing.Common turns out to be the real
+    // Microsoft assembly (Windows-only GDI+ P/Invoke layer, throws PlatformNotSupportedException
+    // or a loader exception for font access off Windows), there is no managed way to build a
+    // working Font. This
+    // produces an uninitialized Font instance (skips its constructor and therefore the native Gdip
+    // call) purely so Control/Label field initializers have a non-null placeholder to hold; it must
+    // never be measured or painted with - callers only need it to avoid crashing during construction.
+    static readonly Font s_unusableFallback =
+        (Font)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(Font));
+
+    internal static Font DefaultFont => Resolve(() => SystemFonts.DefaultFont);
+
+    internal static Font MenuFont => Resolve(() => SystemFonts.MenuFont);
+
+    static Font Resolve(Func<Font> systemFontsAccessor)
+    {
+        try { return systemFontsAccessor(); }
+        catch (Exception exception) when (IsUnsupportedPlatformFontException(exception))
+        {
+            return s_unusableFallback;
+        }
+    }
+
+    static bool IsUnsupportedPlatformFontException(Exception exception) =>
+        exception is PlatformNotSupportedException or DllNotFoundException or EntryPointNotFoundException
+        || exception is TypeInitializationException { InnerException: { } innerException }
+            && IsUnsupportedPlatformFontException(innerException);
+}
+
 public interface IWin32Window
 {
     IntPtr Handle { get; }
@@ -254,9 +291,9 @@ public class Control : Component, IWin32Window, ISynchronizeInvoke, IPortableWin
 
     public virtual bool ContainsFocus => Focused || Controls.Any(static control => control.ContainsFocus);
 
-    public Font Font { get; set; } = SystemFonts.DefaultFont;
+    public Font Font { get; set; } = SafePortableSystemFonts.DefaultFont;
 
-    public static Font DefaultFont => SystemFonts.DefaultFont;
+    public static Font DefaultFont => SafePortableSystemFonts.DefaultFont;
 
     public Cursor Cursor { get; set; } = Cursors.Default;
 
@@ -6147,7 +6184,7 @@ public class AxHost : Control
 
 public class FontDialog : Component
 {
-    public Font? Font { get; set; } = SystemFonts.DefaultFont;
+    public Font? Font { get; set; } = SafePortableSystemFonts.DefaultFont;
 
     public bool ShowEffects { get; set; } = true;
 
@@ -6169,7 +6206,7 @@ public class FontDialog : Component
 
     protected virtual bool RunDialog(IntPtr hwndOwner)
     {
-        Font initialFont = Font ?? SystemFonts.DefaultFont;
+        Font initialFont = Font ?? SafePortableSystemFonts.DefaultFont;
         var request = new PortableFontDialogRequest(
             initialFont.Name,
             initialFont.Size,
@@ -7663,7 +7700,7 @@ public class TreeView : Control
 
     public TreeNodeCollection Nodes { get; }
 
-    public static new Font DefaultFont => SystemFonts.DefaultFont;
+    public static new Font DefaultFont => SafePortableSystemFonts.DefaultFont;
 
     public TreeNode? SelectedNode
     {
@@ -10320,7 +10357,7 @@ public static class SystemInformation
 
     public static Size DragSize => new(4, 4);
 
-    public static Font MenuFont => SystemFonts.MenuFont;
+    public static Font MenuFont => SafePortableSystemFonts.MenuFont;
 
     public static int MouseWheelScrollLines => 3;
 
@@ -10636,7 +10673,7 @@ public class AmbientProperties
 {
     public Color BackColor { get; set; } = SystemColors.Control;
     public Cursor? Cursor { get; set; }
-    public Font Font { get; set; } = SystemFonts.DefaultFont;
+    public Font Font { get; set; } = SafePortableSystemFonts.DefaultFont;
     public Color ForeColor { get; set; } = SystemColors.ControlText;
 }
 

--- a/src/System.Drawing.Common/src/System/Drawing/SystemFonts.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/SystemFonts.cs
@@ -167,32 +167,39 @@ public static class SystemFonts
         {
             Font? defaultFont = null;
 
-            // For Arabic systems, always return Tahoma 8.
-            if (PInvokeCore.GetSystemDefaultLCID() == PInvoke.LANG_ARABIC)
+            // GetSystemDefaultLCID/GetStockObject below are Win32-only (no macOS/Linux P/Invoke
+            // shim exists for either) - on a non-Windows platform, skip straight to the portable
+            // fallback chain (Tahoma, then GenericSansSerif) instead of throwing
+            // EntryPointNotFoundException the first time any Control is constructed.
+            if (OperatingSystem.IsWindows())
             {
-                try
+                // For Arabic systems, always return Tahoma 8.
+                if (PInvokeCore.GetSystemDefaultLCID() == PInvoke.LANG_ARABIC)
                 {
-                    defaultFont = new Font("Tahoma", 8);
+                    try
+                    {
+                        defaultFont = new Font("Tahoma", 8);
+                    }
+                    catch (Exception ex) when (!IsCriticalFontException(ex)) { }
                 }
-                catch (Exception ex) when (!IsCriticalFontException(ex)) { }
+
+                // First try DEFAULT_GUI.
+                if (defaultFont is null)
+                {
+                    HFONT handle = (HFONT)PInvokeCore.GetStockObject(GET_STOCK_OBJECT_FLAGS.DEFAULT_GUI_FONT);
+                    try
+                    {
+                        using Font fontInWorldUnits = Font.FromHfont(handle);
+                        defaultFont = FontInPoints(fontInWorldUnits);
+                    }
+                    catch (ArgumentException)
+                    {
+                        // This can happen in theory if we end up pulling a non-TrueType font
+                    }
+                }
             }
 
-            // First try DEFAULT_GUI.
-            if (defaultFont is null)
-            {
-                HFONT handle = (HFONT)PInvokeCore.GetStockObject(GET_STOCK_OBJECT_FLAGS.DEFAULT_GUI_FONT);
-                try
-                {
-                    using Font fontInWorldUnits = Font.FromHfont(handle);
-                    defaultFont = FontInPoints(fontInWorldUnits);
-                }
-                catch (ArgumentException)
-                {
-                    // This can happen in theory if we end up pulling a non-TrueType font
-                }
-            }
-
-            // If DEFAULT_GUI didn't work, try Tahoma.
+            // If DEFAULT_GUI didn't work (or we're not on Windows), try Tahoma.
             if (defaultFont is null)
             {
                 try
@@ -225,7 +232,7 @@ public static class SystemFonts
         {
             Font? dialogFont = null;
 
-            if (PInvokeCore.GetSystemDefaultLCID() == PInvoke.LANG_JAPANESE)
+            if (OperatingSystem.IsWindows() && PInvokeCore.GetSystemDefaultLCID() == PInvoke.LANG_JAPANESE)
             {
                 // Always return DefaultFont for Japanese cultures.
                 dialogFont = DefaultFont;

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -1650,7 +1650,29 @@ public unsafe partial class Control :
         {
             if (s_defaultFont is null)
             {
-                s_defaultFont = Application.DefaultFont ?? SystemFonts.MessageBoxFont;
+                // SystemFonts.MessageBoxFont/DialogFont/DefaultFont ultimately go through
+                // Font.FromHfont, which the real System.Drawing.Common throws
+                // PlatformNotSupportedException from unconditionally off Windows (a deliberate
+                // managed-code guard in dotnet/runtime, not a missing P/Invoke) - every
+                // Control's constructor reaches this getter, so without a portable fallback here
+                // no WinForms Control can ever be constructed at all off Windows. FontFamily's
+                // own constructor has no such platform gate.
+                if (!OperatingSystem.IsWindows())
+                {
+                    try
+                    {
+                        s_defaultFont = Application.DefaultFont ?? SystemFonts.MessageBoxFont;
+                    }
+                    catch (PlatformNotSupportedException)
+                    {
+                        s_defaultFont = new Font(FontFamily.GenericSansSerif, 8.25f);
+                    }
+                }
+                else
+                {
+                    s_defaultFont = Application.DefaultFont ?? SystemFonts.MessageBoxFont;
+                }
+
                 Debug.Assert(s_defaultFont is not null, "defaultFont wasn't set!");
             }
 


### PR DESCRIPTION
## Summary

- avoid Win32-only system font lookups on non-Windows platforms
- keep portable controls constructible when a host loads Microsoft `System.Drawing.Common` before LibreWinForms
- fall back only for explicit platform/loader failures; unrelated font errors continue to propagate
- add a macOS regression test that loads Microsoft `System.Drawing.Common` first in an isolated assembly context

## Validation

- `git diff --check upstream/librewinforms-progpu-port...HEAD`
- `DOTNET_ROLL_FORWARD=Major ./eng/common/dotnet.sh run --project src/LibreWinForms.Portable/LibreWinForms.System.Windows.Forms.Tests/LibreWinForms.System.Windows.Forms.Tests.csproj --configuration Release --no-restore`
  - Microsoft System.Drawing.Common host-first regression passed
  - complete LibreWinForms behavior suite passed